### PR TITLE
README update & Coordinate transformation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ $ python voc2coco.py \
     <option> --ext xml
 ```
 
-
 ##### 2.2 Usage 2(Use annotation paths list)
+
+**Sample paths.txt**
+
+```txt
+/path/to/annotation/file.xml
+/path/to/annotation/file2.xml
+...
+```
 
 ```bash
 $ python voc2coco.py \
@@ -49,7 +56,7 @@ $ python voc2coco.py \
 In this case, you can convert [Shenggan/BCCD_Dataset: BCCD Dataset is a small-scale dataset for blood cells detection.](https://github.com/Shenggan/BCCD_Dataset) by this script.
 
 ```bash
-$ python voc2coco.py \                                                                                                                                              金  5/24 20:14:59 2019
+$ python voc2coco.py
     --ann_dir sample/Annotations \
     --ann_ids sample/dataset_ids/test.txt \
     --labels sample/labels.txt \
@@ -57,10 +64,10 @@ $ python voc2coco.py \                                                          
     --ext xml
 
 # Check output
-$ ls sample/ | grep bccd_test_cocoformat.json                                                                                                                    金  5/24 20:16:09 2019
+$ ls sample/ | grep bccd_test_cocoformat.json
 bccd_test_cocoformat.json
 
 # Check output
-cut -f -4 -d , sample/bccd_test_cocoformat.json                                                                                                                金  5/24 20:20:49 2019
+cut -f -4 -d , sample/bccd_test_cocoformat.json
 {"images": [{"file_name": "BloodImage_00007.jpg", "height": 480, "width": 640, "id": "BloodImage_00007"}
 ```

--- a/voc2coco.py
+++ b/voc2coco.py
@@ -62,10 +62,10 @@ def get_coco_annotation_from_obj(obj, label2id):
     assert label in label2id, f"Error: {label} is not in label2id !"
     category_id = label2id[label]
     bndbox = obj.find('bndbox')
-    xmin = int(bndbox.findtext('xmin')) - 1
-    ymin = int(bndbox.findtext('ymin')) - 1
-    xmax = int(bndbox.findtext('xmax'))
-    ymax = int(bndbox.findtext('ymax'))
+    xmin = int(float(bndbox.findtext('xmin'))) - 1
+    ymin = int(float(bndbox.findtext('ymin'))) - 1
+    xmax = int(float(bndbox.findtext('xmax')))
+    ymax = int(float(bndbox.findtext('ymax')))
     assert xmax > xmin and ymax > ymin, f"Box size error !: (xmin, ymin, xmax, ymax): {xmin, ymin, xmax, ymax}"
     o_width = xmax - xmin
     o_height = ymax - ymin


### PR DESCRIPTION
### add paths.txt sample and remove bash profile info
Along with labels.txt, paths.txt file example is added on README.

### receive label coordinates as float types before integer transformation
x, y coordinates are in float format (ex: 369.0), thus changing str -> float should take place first.

